### PR TITLE
ci: fix missing `reference=` in filter syntax of `docker image`

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -132,7 +132,7 @@ jobs:
 
           # get subject digest
           DIGEST=$(
-            docker images --filter="${NAME}" --format="{{ json . }}" \
+            docker images --filter="reference=${NAME}" --format="{{ json . }}" \
             | head -n1 \
             | jq -r ".Digest"
           )

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -88,6 +88,9 @@ jobs:
           install-dir: "/usr/bin"
           use-sudo: true
 
+      - name: "Expose GitHub Runtime"
+        uses: "crazy-max/ghaction-github-runtime@v3.0.0"
+
       - name: "Build image"
         env:
           COSIGN_PRIVATE_KEY: "${{ secrets.SIGNING_SECRET }}"


### PR DESCRIPTION
- Fix missing `reference=` in filter syntax of `docker image`.
- Add expose step to use GitHub Actions cache.