### PR TITLE
ci: fix issues of fails to get attest subject

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -140,8 +140,9 @@ jobs:
           echo "subject_name=${NAME}" | tee -a ${GITHUB_OUTPUT}
 
           # get subject digest
+          docker pull "${NAME}:latest"
           DIGEST=$(
-            docker images --filter="reference=${NAME}" --format="{{ json . }}" \
+            docker images --filter="reference=${NAME}:latest" --format="{{ json . }}" \
             | head -n1 \
             | jq -r ".Digest"
           )
@@ -153,4 +154,3 @@ jobs:
         with:
           subject-name: "${{ steps.get_attest_subject.outputs.subject_name }}"
           subject-digest: "${{ steps.get_attest_subject.outputs.subject_digest }}"
-          push-to-registry: true

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -91,12 +91,6 @@ jobs:
       - name: "Expose GitHub Runtime"
         uses: "crazy-max/ghaction-github-runtime@v3.0.0"
 
-      - name: "Add alt-tags to recipe"
-        if: ${{ github.event_name == 'release' }}
-        run: |
-          yq e ".alt-tags += '${{ github.event.release.tag_name }}'" \
-            -i ./recipes/${{ matrix.recipe }}.yaml
-
       - name: "Build image"
         env:
           COSIGN_PRIVATE_KEY: "${{ secrets.SIGNING_SECRET }}"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -91,6 +91,12 @@ jobs:
       - name: "Expose GitHub Runtime"
         uses: "crazy-max/ghaction-github-runtime@v3.0.0"
 
+      - name: "Add alt-tags to recipe"
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          yq e ".alt-tags += '${{ github.event.release.tag_name }}'" \
+            -i ./recipes/${{ matrix.recipe }}.yaml
+
       - name: "Build image"
         env:
           COSIGN_PRIVATE_KEY: "${{ secrets.SIGNING_SECRET }}"

--- a/recipes/main.yaml
+++ b/recipes/main.yaml
@@ -6,6 +6,9 @@ description: "A desktop Linux image based for Fedora Kinoite and customized for 
 base-image: "ghcr.io/ublue-os/kinoite-main"
 image-version: "41"
 
+alt-tags:
+  - "latest"
+
 modules:
   - type: "files"
     files:


### PR DESCRIPTION
- Add image alt-tags `latest` to recipe.
- Add image pull process before get subject digests.