### PR TITLE
ci: fix tag format for OS container image

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -130,7 +130,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ steps.get_metadata.outputs.image_name }}
           tags: |
             type=raw,value={{date 'YYYYMMDD'}},prefix=${{ steps.get_metadata.outputs.image_version }}.,suffix=.0,enable=${{ github.event_name == 'pull_request' }}
-            type=semver,pattern={{version}},prefix=${{ steps.get_metadata.outputs.image_version }}.,enable=${{ github.event_name == 'release' }}
+            type=pep440,pattern={{version}},prefix=${{ steps.get_metadata.outputs.image_version }}.,enable=${{ github.event_name == 'release' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
           labels: |
             org.opencontainers.image.authors=${{ steps.get_metadata.outputs.image_authors }}


### PR DESCRIPTION
Fix tag format for OS container image.

Reference: <https://github.com/RShirohara/grand-os/actions/runs/13310199093/job/37170562040>