### PR TITLE
ci: fix dependency version syntax for internal container `kde-rounded-corners`

### DIFF
--- a/containers/kde-rounded-corners/Containerfile
+++ b/containers/kde-rounded-corners/Containerfile
@@ -13,7 +13,7 @@ RUN dnf install --assumeyes \
         cmake \
         gcc-c++ \
         extra-cmake-modules \
-        kwin-devel-${KWIN_VERSION}-1.fc${BUILDER_VERSION} \
+        kwin-devel-${KWIN_VERSION}-*.fc${BUILDER_VERSION} \
         kf6-kconfigwidgets-devel \
         libepoxy-devel \
         kf6-kcmutils-devel \


### PR DESCRIPTION
Fix dependency version syntax for internal container `kde-rounded-corners`.