### PR TITLE
ci: fix build not running when creating a release from GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: "Create release"
         env:
           CURRENT_VERSION: "${{ needs.check_release_version.outputs.current_version }}"
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.RELEASE_PAT }}"
           REPOSITORY: "${{ github.repository }}"
         run: |
           set -o "errexit" -o "nounset"


### PR DESCRIPTION
Fix build not running when creating a release from GitHub Actions.

Ref: <https://github.com/orgs/community/discussions/25281>