### PR TITLE
fix: change base image to `quay.io/fedora-ostree-desktops/kinoite`

### DIFF
--- a/recipes/main.yaml
+++ b/recipes/main.yaml
@@ -3,7 +3,7 @@
 name: "grand-os/main"
 description: "A desktop Linux image based for Fedora Kinoite and customized for personal use."
 
-base-image: "ghcr.io/ublue-os/kinoite-main"
+base-image: "quay.io/fedora-ostree-desktops/kinoite"
 image-version: "41"
 
 modules:

--- a/recipes/main.yaml
+++ b/recipes/main.yaml
@@ -7,6 +7,14 @@ base-image: "quay.io/fedora-ostree-desktops/kinoite"
 image-version: "41"
 
 modules:
+  # `ublue-os/kinoite-main:41` を利用してビルドするとインストールに失敗するため、
+  # `quay.io/fedora-ostree-desktops/kinoite` をベースにしたうえで `ublue-os` のカスタムを適用する。
+  - from-file: "./modules/ublue-os/copy/config.yaml"
+  - from-file: "./modules/ublue-os/copy/akmods.yaml"
+  - from-file: "./modules/ublue-os/copy/akmods-kernel.yaml"
+  - from-file: "./modules/ublue-os/script.yaml"
+
+  # `rshirohara/grand-os` customs.
   - from-file: "./modules/rpm-ostree.yaml"
   - from-file: "./modules/default-flatpaks.yaml"
   - from-file: "./modules/brew.yaml"

--- a/recipes/modules/ublue-os/copy/akmods-kernel.yaml
+++ b/recipes/modules/ublue-os/copy/akmods-kernel.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/modules/copy.json
+
+type: "copy"
+from: "ghcr.io/ublue-os/akmods:main-41"
+src: "/kernel-rpms"
+dest: "/tmp/kernel-rpms"

--- a/recipes/modules/ublue-os/copy/akmods.yaml
+++ b/recipes/modules/ublue-os/copy/akmods.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/modules/copy.json
+
+type: "copy"
+from: "ghcr.io/ublue-os/akmods:main-41"
+src: "/rpms/ublue-os"
+dest: "/tmp/akmods-rpms"

--- a/recipes/modules/ublue-os/copy/config.yaml
+++ b/recipes/modules/ublue-os/copy/config.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/modules/copy.json
+
+type: "copy"
+from: "ghcr.io/ublue-os/config:latest"
+src: "/rpms"
+dest: "/tmp/rpms"

--- a/recipes/modules/ublue-os/script.yaml
+++ b/recipes/modules/ublue-os/script.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/modules/script-v1.json
+
+type: "script"
+snippets:
+  - 'mkdir -p "/ctx"'
+  - 'curl --location --output "/tmp/ctx.tar.gz" "https://api.github.com/repos/ublue-os/main/tarball"'
+  - 'tar --extract --verbose --file="/tmp/ctx.tar.gz" --directory="/ctx" --strip-components=1'
+  - 'rm -f /usr/bin/chsh'
+  - 'rm -f /usr/bin/lchsh'
+  # remove unused dependency `mesa-libglapi`.
+  # ref: <https://github.com/ublue-os/main/pull/723>
+  - 'sed --in-place --regex --expression="59 d" --expression="50 s/(.*+)/\1\n  --remove=mesa-libglapi \\\\/" /ctx/install.sh'
+  - IMAGE_NAME="kinoite" FEDORA_MAJOR_VERSION="41" KERNEL_VERSION=$(skopeo inspect docker://ghcr.io/ublue-os/akmods:main-41 | jq -r '.Labels["ostree.linux"]') /ctx/install.sh
+  - '/ctx/post-install.sh'
+  # remove bluebuild mounted files from cleanup target.
+  - 'sed --in-place --expression="6 s#/tmp/\*#/tmp/!(files|modules|scripts)#" --expression="8 s#!(rpm-ostree)#!(rpm-ostree|libdnf5)#" /ctx/cleanup.sh'
+  - '/ctx/cleanup.sh'
+  - 'ostree container commit'
+  - 'mkdir -p /var/tmp'
+  - 'chmod -R 1777 /var/tmp'
+  - 'rm -rf /ctx'


### PR DESCRIPTION
Fix issues
Change base image from `ghcr.io/ublue-os/kinoite-main` to `quay.io/fedora-ostree-desktops/kinoite`, to correct a problem with the installer failing to run.
Upstream issue: https://github.com/JasonN3/build-container-installer/issues/150