### PR TITLE
fix: add `bootc` option to topgrade config

### DIFF
--- a/files/system/usr/share/topgrade/topgrade.toml
+++ b/files/system/usr/share/topgrade/topgrade.toml
@@ -5,4 +5,5 @@ assume_yes = true
 no_retry = false
 
 [linux]
+bootc = true
 rpm_ostree = true


### PR DESCRIPTION
Add `bootc` option to topgrade config and use `bootc` in `topgrade`.