### PR TITLE
fix: issue where Cosign public key cannot be verified in PRs created by DependaBot

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -8,7 +8,6 @@ on:
     paths:
       - ".github/workflows/build-image.yaml"
       - "files/**/*"
-      - "modules/**/*"
       - "recipes/**/*"
   release:
     types: "released"
@@ -92,6 +91,7 @@ jobs:
           install-dir: "${{ runner.temp }}/cosign/bin"
 
       - name: "Validate cosign key-pair"
+        if: ${{ github.event_name == 'pull_request' && ( github.event.pull_request.user.login == github.event.repository.owner.login ) }}
         env:
           COSIGN_PASSWORD: "${{ secrets.COSIGN_PASSWORD }}"
           COSIGN_PRIVATE_KEY: "${{ secrets.COSIGN_PRIVATE_KEY }}"

--- a/.github/workflows/build-internal-image.yaml
+++ b/.github/workflows/build-internal-image.yaml
@@ -92,6 +92,7 @@ jobs:
           install-dir: "${{ runner.temp }}/cosign/bin"
 
       - name: "Validate cosign key-pair"
+        if: ${{ github.event_name == 'pull_request' && ( github.event.pull_request.user.login == github.event.repository.owner.login ) }}
         env:
           COSIGN_PASSWORD: "${{ secrets.COSIGN_PASSWORD }}"
           COSIGN_PRIVATE_KEY: "${{ secrets.COSIGN_PRIVATE_KEY }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,15 +35,15 @@ jobs:
 
           echo "event_name=${{ github.event_name }}"
 
-          # Trigger が `pull_request` の場合、実行可能
+          # Trigger が `pull_request` の場合、実行可能。
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             IS_RUNNABLE="true"
             echo "is_runnable=${IS_RUNNABLE}" | tee --append "${GITHUB_OUTPUT}"
             exit 0
           fi
 
-          # Trigger が `push` の場合、紐づく PullRequest の Label に
-          # `Type: Release` が含まれている場合のみ実行可能
+          # Trigger が `push` の場合、紐づく Pull Request の Label に
+          # `Type: Release` が含まれている場合のみ実行可能。
           if [[ "${{ github.event_name }}" == "push" ]]; then
             set +o "errexit"
             PR_NUMBER=$(


### PR DESCRIPTION
Prohibit Cosign public key verification in PRs created by someone other than the repository owner.