### PR TITLE
fix: issues for `v20250302.0`

### DIFF
--- a/files/system/etc/profile.d/gnupg.sh
+++ b/files/system/etc/profile.d/gnupg.sh
@@ -5,7 +5,7 @@ export GPG_SOCKET_DIR=$(gpgconf --list-dirs socketdir)
 
 find /usr/share/gnupg/systemd-unit-template -type "f" \
 | while read -r PATH; do \
-    FILE_NAME="${PATH##.*/}"
+    FILE_NAME="${PATH##*/}"
     SYSTEMD_UNIT_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/systemd/user"
     /usr/bin/mkdir --parents "${SYSTEMD_UNIT_DIR}"
     /usr/bin/sed --expression="s|\${GPG_SOCKET_DIR}|${GPG_SOCKET_DIR}|g" \


### PR DESCRIPTION
- Fix environment extraction in gnupg profile script.
- ~~Downglade build dependency `kwin-devel` to `6.3.1`.~~