### PR TITLE
ci: fix string quotes to single-quote

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -83,7 +83,7 @@ jobs:
 
           $(
             _COMMITS=$(
-              echo "${{ steps.generate_changelog.outputs.changelog }}" \
+              echo '${{ steps.generate_changelog.outputs.changelog }}' \
               | jq --raw-output ".[]" \
               | sed --expression="s|^|- |g"
             )


### PR DESCRIPTION
Fix double-quotes to single-quote,
Because an error occurs when a JSON string is inserted.

Issues: <https://github.com/RShirohara/grand-os/actions/runs/13701926853/job/38317702572#step:6:45>