### PR TITLE
ci: fix typo on release-automation workflow

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -101,7 +101,7 @@ jobs:
               --in-place \
               ./files/scripts/update-os-release.sh
           git switch --create "${GIT_RELEASE_BRANCH}"
-          git add ./files/scripts/update-op-release.sh
+          git add ./files/scripts/update-os-release.sh
           git commit --file="./description.sh"
 
           # create PR


### PR DESCRIPTION
Fix filename typo.

Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702091634/job/38318254651#step:6:46>