### PR TITLE
ci: fix filename typo on pr automation

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -102,7 +102,7 @@ jobs:
               ./files/scripts/update-os-release.sh
           git switch --create "${GIT_RELEASE_BRANCH}"
           git add ./files/scripts/update-os-release.sh
-          git commit --file="./description.sh"
+          git commit --file="./description.md"
 
           # create PR
           git pr create \


### PR DESCRIPTION
Fix typo for filename.
Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702196146/job/38318601171#step:6:46>