### PR TITLE
ci: fix command-name typo

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -105,7 +105,7 @@ jobs:
           git commit --file="./description.md"
 
           # create PR
-          git pr create \
+          gh pr create \
               --fill-verbose \
               --assignee="@${{ github.repository_owner }}" \
               --reviewer="@${{ github.repository_owner }}"


### PR DESCRIPTION
Fix command-name typo in workflow.
Issue: <https://github.com/RShirohara/grand-os/actions/runs/13702275245/job/38318873666#step:6:52>