### PR TITLE
ci: add missing push process

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -103,6 +103,7 @@ jobs:
           git switch --create "${GIT_RELEASE_BRANCH}"
           git add ./files/scripts/update-os-release.sh
           git commit --file="./description.md"
+          git push --set-upstream origin "${GIT_RELEASE_BRANCH}"
 
           # create PR
           gh pr create \


### PR DESCRIPTION
Fix issue where the Push process was missing.
Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702358377/job/38319149442#step:6:49>