### PR TITLE
ci: add missing `contents` permission` to workflow

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -18,6 +18,9 @@ jobs:
     name: "Create PR"
     runs-on: "ubuntu-latest"
 
+    permissions:
+      contents: "write"
+
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4.2.2"


### PR DESCRIPTION
Fix issue where write permission was missing.
Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702486032/job/38319575080#step:6:50>