### PR TITLE
ci: remove GitHub user prefix

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -111,6 +111,6 @@ jobs:
           # create PR
           gh pr create \
               --fill-verbose \
-              --assignee="@${{ github.repository_owner }}" \
-              --reviewer="@${{ github.repository_owner }}"
+              --assignee="${{ github.repository_owner }}" \
+              --reviewer="${{ github.repository_owner }}"
 


### PR DESCRIPTION
Fix issues where the GitHub user was missing.
Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702638406/job/38320073715#step:6:57>
