### PR TITLE
ci: add missing permission `pull-requests`

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -20,6 +20,7 @@ jobs:
 
     permissions:
       contents: "write"
+      pull-requests: "write"
 
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
Add permissions `pull-request` to workflow.
Issues: <https://github.com/RShirohara/grand-os/actions/runs/13702757613/job/38320472333>