### PR TITLE
ci: fix problem with release PR creation fails

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -117,10 +117,10 @@ jobs:
           gh api graphql \
               -F githubRepository="${{ github.repository }}" \
               -F branchName="${GIT_RELEASE_BRANCH}" \
-              -F expectedHeadOid="$(git rev-parse "origin/${GIT_DEFAULT_BRANCH}")" \
+              -F expectedHeadOid="$(git rev-parse HEAD)" \
               -F commitMessage="$(cat ./message.md)" \
               -F commitDetail="$(cat ./detail.md)" \
-              -F files[][path]="./files/scripts/update-os-release.sh" \
+              -F files[][path]="files/scripts/update-os-release.sh" \
               -F files[][contents]="$(base64 -w0 ./files/scripts/update-os-release.sh)" \
               -F query=@.github/api/create-commit.graphql
 


### PR DESCRIPTION
Change file referencing method,
as the file referencing method
was incorrect and the commit creation failed.

Fixes: <https://github.com/RShirohara/grand-os/actions/runs/13723592182>