### PR TITLE
ci: Fix problem with commits

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -109,8 +109,8 @@ jobs:
           set -o "errexit" -o "nounset"
 
           sed --expression="s|^RELEASE_VERSION=\".*\"$|RELEASE_VERSION=\"${{ steps.increase_version.outputs.version }}\"|g" \
-              --in-place \
               ./files/scripts/update-os-release.sh
+              > ./update-os-release.sh
 
           git switch --create "${GIT_RELEASE_BRANCH}"
           git push --set-upstream origin "${GIT_RELEASE_BRANCH}"
@@ -121,7 +121,7 @@ jobs:
               -F commitMessage="$(cat ./message.md)" \
               -F commitDetail="$(cat ./detail.md)" \
               -F files[][path]="files/scripts/update-os-release.sh" \
-              -F files[][contents]="$(base64 -w0 ./files/scripts/update-os-release.sh)" \
+              -F files[][contents]="$(base64 -w0 ./update-os-release.sh)" \
               -F query=@.github/api/create-commit.graphql
 
           git pull --prune
@@ -134,6 +134,5 @@ jobs:
 
           gh pr create \
               --fill-verbose \
-              --head="${GIT_RELEASE_BRANCH}" \
               --assignee="${{ github.repository_owner }}" \
               --reviewer="${{ github.repository_owner }}"


### PR DESCRIPTION
containing modified files failing

When applying changes,
the file was saved as a replacement for an existing file.
However, `createCommitOnBranch` sends the contents of the file directly,
so the subsequent `git pull` will conflict with the changes.
Avoid problems with conflicting changes by writing all changes
to a temporary file.

Fixes: <https://github.com/RShirohara/grand-os/actions/runs/13724010367>