### PR TITLE
ci: fix issues where build-os workflow was not start on PR created

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -12,6 +12,7 @@ on:
 env:
   GIT_DEFAULT_BRANCH: "main"
   GIT_RELEASE_BRANCH: "bump-os-image-version"
+  GITHUB_RELEASE_LABEL: "Type: Release"
 
 jobs:
   create_pr:
@@ -136,4 +137,5 @@ jobs:
               --draft \
               --fill-verbose \
               --assignee="${{ github.repository_owner }}"
+              --label="${GITHUB_RELEASE_LABEL}"
           gh pr ready

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -99,7 +99,7 @@ jobs:
 
           ## Note
 
-          This pull request created by workflow triggered by ${{ github.event_name }}.
+          This pull request was created by workflow triggered by ${{ github.event_name }}.
           Additional info: "${{ github.event.inputs.info || 'None.' }}"
           MESSAGE
 

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -134,8 +134,8 @@ jobs:
           set -o "errexit" -o "nounset"
 
           gh pr create \
+              --assignee="${{ github.repository_owner }}" \
               --draft \
               --fill-verbose \
-              --assignee="${{ github.repository_owner }}"
               --label="${GITHUB_RELEASE_LABEL}"
           gh pr ready

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -133,6 +133,7 @@ jobs:
           set -o "errexit" -o "nounset"
 
           gh pr create \
+              --draft \
               --fill-verbose \
-              --assignee="${{ github.repository_owner }}" \
-              --reviewer="${{ github.repository_owner }}"
+              --assignee="${{ github.repository_owner }}"
+          gh pr ready


### PR DESCRIPTION
- Add "create draft PR" -> "ready for review" process.
- Add missing PR label "Type: Release".
- Fix typo.