### PR TITLE
feat: add `WM.activeFont` property to kde global setting

### DIFF
--- a/files/system/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
+++ b/files/system/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
@@ -19,3 +19,6 @@ widgetStyle=kvantum-dark
 [Toolbar style]
 ToolButtonStyle=NoText
 ToolButtonStyleOtherToolbars=NoText
+
+[WM]
+activeFont=Noto Sans CJK JP,11,-1,5,300,0,0,0,0,0,0,0,0,0,0,1,Light


### PR DESCRIPTION
Fix problem with font settings not being applied to window titles after initial setup.