### PR TITLE
fix: issue where certificate validation fails when pulling container images containing build attestation

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -200,6 +200,7 @@ jobs:
 
           cosign sign \
             --key="env://COSIGN_PRIVATE_KEY" \
+            --recursive \
             "${IMAGE_NAME}@${IMAGE_DIGEST}"
 
       - name: "Attest build provenance for image"

--- a/.github/workflows/build-internal-image.yaml
+++ b/.github/workflows/build-internal-image.yaml
@@ -221,6 +221,7 @@ jobs:
 
           cosign sign \
             --key="env://COSIGN_PRIVATE_KEY" \
+            --recursive \
             "${IMAGE_NAME}@${IMAGE_DIGEST}"
 
       - name: "Attest build provenance for image"


### PR DESCRIPTION
The [`docker/build-push-action`](https://github.com/docker/build-push-action) used in the GrandOS build process including Attestation in container image by default.  
On the other hand, Cosign cannot generate a signature for an image containing multiple references without adding the `--recursive` flag, which causes problems when the image is retrieved using `podman pull`.