### PR TITLE
chore(deps): fix dependabot issues

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,8 @@ version: 2
 updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
     schedule:
       interval: "monthly"
       time: "03:00"

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Get recipes"
         id: "get_recipes"
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Setup Docker Buildx"
-        uses: "docker/setup-buildx-action@v3.10.0"
+        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
         with:
           install: true
 
@@ -87,7 +87,7 @@ jobs:
           "${BLUEBUILD_INSTALL_DIR}/bluebuild" --version
 
       - name: "Setup cosign cli"
-        uses: "sigstore/cosign-installer@v3.8.1"
+        uses: "sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a" # v3.8.1
         with:
           install-dir: "${{ runner.temp }}/cosign/bin"
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: "Build metadata"
         id: "build_metadata"
-        uses: "docker/metadata-action/@v5.6.1"
+        uses: "docker/metadata-action/@369eb591f429131d6889c46b94e711f089e6ca96" # v5.6.1
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ steps.get_metadata.outputs.image_name }}
@@ -148,7 +148,7 @@ jobs:
             org.opencontainers.image.title=${{ steps.get_metadata.outputs.image_name }}
 
       - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@v3.4.0"
+        uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"
@@ -170,7 +170,7 @@ jobs:
 
       - name: "Build image (and publish on release)"
         id: "build_image"
-        uses: "docker/build-push-action@v6.15.0"
+        uses: "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4" # v6.15.0
         with:
           annotations: |
             ${{ steps.build_metadata.outputs.annotations }}
@@ -205,7 +205,7 @@ jobs:
 
       - name: "Attest build provenance for image"
         if: ${{ github.event_name == 'release' }}
-        uses: "actions/attest-build-provenance@v2.2.3"
+        uses: "actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2" # v2.2.3
         with:
           subject-name: "ghcr.io/${{ github.repository_owner }}/${{ steps.get_metadata.outputs.image_name }}"
           subject-digest: "${{ steps.build_image.outputs.digest }}"

--- a/.github/workflows/build-internal-image.yaml
+++ b/.github/workflows/build-internal-image.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           fetch-depth: 0
 
@@ -78,15 +78,15 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Setup Docker Buildx"
-        uses: "docker/setup-buildx-action@v3.10.0"
+        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
         with:
           install: true
 
       - name: "Setup cosign cli"
-        uses: "sigstore/cosign-installer@v3.8.1"
+        uses: "sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a" # v3.8.1
         with:
           install-dir: "${{ runner.temp }}/cosign/bin"
 
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: "Login to GitHub Container Registry"
-        uses: "docker/login-action@v3.4.0"
+        uses: "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772" # v3.4.0
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"
@@ -161,7 +161,7 @@ jobs:
 
       - name: "Build metadata"
         id: "build_metadata"
-        uses: "docker/metadata-action@v5.7.0"
+        uses: "docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804" # v5.7.0
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ fromJson(steps.get_metadata.outputs.image_metadata)['org.opencontainers.image.title'] }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: "Build image (and publish on main branch)"
         id: "build_image"
-        uses: "docker/build-push-action@v6.15.0"
+        uses: "docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4" # v6.15.0
         with:
           annotations: |
             ${{ steps.build_metadata.outputs.annotations }}
@@ -226,7 +226,7 @@ jobs:
 
       - name: "Attest build provenance for image"
         if: ${{ github.event_name == 'push' }}
-        uses: "actions/attest-build-provenance@v2.2.3"
+        uses: "actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2" # v2.2.3
         with:
           subject-name: "ghcr.io/${{ github.repository_owner }}/${{ fromJson(steps.get_metadata.outputs.image_metadata)['org.opencontainers.image.title'] }}"
           subject-digest: "${{ steps.build_image.outputs.digest }}"

--- a/.github/workflows/check-actions.yaml
+++ b/.github/workflows/check-actions.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Setup actionlint"
         env:
@@ -43,7 +43,7 @@ jobs:
             "${ACTIONLINT_INSTALL_DIR}"
 
       - name: "Setup reviewdog"
-        uses: "reviewdog/action-setup@v1.3.2"
+        uses: "reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893" # v1.3.2
 
       - name: "Lint"
         env:

--- a/.github/workflows/check-containerfile.yaml
+++ b/.github/workflows/check-containerfile.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Setup hadolint"
         env:
@@ -45,7 +45,7 @@ jobs:
           "${HADOLINT_INSTALL_DIR}/hadolint" --version
 
       - name: "Setup reviewdog"
-        uses: "reviewdog/action-setup@v1.3.2"
+        uses: "reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893" # v1.3.2
 
       - name: "Lint"
         env:

--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Setup gh extenson `actions/gh-actions-cache`"
         env:

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Get workflow trigger"
         id: "get_trigger"
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Check release version"
         id: "check_version"
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v4.2.2"
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
 
       - name: "Create release"
         env:


### PR DESCRIPTION
- Change property `directory` to `directories` for dependabot config and use glob pattern on `directories` property.
- Pin version for GitHub Actions workflow dependency.