### PR TITLE
fix: issues for `grand-os/main-testing:41.20250413.0`

### DIFF
--- a/files/system/common/usr/bin/code-flatpak
+++ b/files/system/common/usr/bin/code-flatpak
@@ -28,4 +28,6 @@ ARCH=$(
   --arch="${ARCH}" \
   --command=code \
   --file-forwarding \
-  com.visualstudio.code "${@}"
+  com.visualstudio.code \
+  --enable-wayland-ime \
+  "${@}"

--- a/files/system/common/usr/lib/systemd/user-preset/91-grand-os-user-configs-override.preset
+++ b/files/system/common/usr/lib/systemd/user-preset/91-grand-os-user-configs-override.preset
@@ -1,2 +1,2 @@
-enable flatpak-override-update.service
-enable gnupg-unit-update.service
+enable flatpak-override-update.timer
+enable gnupg-unit-update.timer


### PR DESCRIPTION
- Fix issues for systemd user units.
- Fix issues for IME activation on vscode.