### PR TITLE
fix: issues with topgrade targets not showing up

### DIFF
--- a/files/system/common/usr/share/applications/system-update.desktop
+++ b/files/system/common/usr/share/applications/system-update.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=System Update
 Comment=Update GrandOS, Flatpaks, Homebrew formulas, and more.
 Icon=update
-Exec=/usr/bin/topgrade --config="/usr/share/grand-os/system-update/topgrade.toml" \|\| read -p "Update failed!"
+Exec=bash -i -c "/usr/bin/topgrade --config=/usr/share/grand-os/system-update/topgrade.toml" \|\| read -p "Update failed!"
 Terminal=true
 Categories=ConsoleOnly;System;

--- a/files/system/old/usr/share/applications/system-update.desktop
+++ b/files/system/old/usr/share/applications/system-update.desktop
@@ -5,4 +5,4 @@ Comment=Update GrandOS, Flatpaks, Homebrew formulas, and more.
 Icon=update
 Categories=ConsoleOnly;System;
 Terminal=true
-Exec=/usr/bin/topgrade --config="/usr/share/system-update/topgrade.toml" || read -p "Update failed!"
+Exec=bash -i -c "/usr/bin/topgrade --config=/usr/share/system-update/topgrade.toml" || read -p "Update failed!"


### PR DESCRIPTION
The `.desktop` entry does not execute init-scripts in `/etc/profile.d/`,
so same commands (such as HomeBrew) are not selected for updating.

This fix addresses the above problem by starting Bash
in interactive mode and calling Topgrade on it.