### PR TITLE
fix: replace `topgrade` provider to internal container

### DIFF
--- a/recipes/modules/old/copy-container-files.yaml
+++ b/recipes/modules/old/copy-container-files.yaml
@@ -20,6 +20,11 @@ modules:
     dest: "/"
 
   - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/topgrade:latest"
+    src: "/"
+    dest: "/"
+
+  - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:latest"
     src: "/"
     dest: "/"

--- a/recipes/modules/old/setup-packages.yaml
+++ b/recipes/modules/old/setup-packages.yaml
@@ -4,7 +4,6 @@ modules:
   - type: "rpm-ostree"
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
-      - "https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-%OS_VERSION%/lilay-topgrade-fedora-%OS_VERSION%.repo"
       - "https://packagecloud.io/install/repositories/filips/FirefoxPWA/config_file.repo?os=rpm_any&dist=rpm_any&source=script"
     keys:
       - "https://packagecloud.io/filips/FirefoxPWA/gpgkey"
@@ -21,7 +20,6 @@ modules:
       - "kvantum"
       - "libappindicator"
       - "libdbusmenu"
-      - "topgrade"
     remove:
       - "distrobox"
       - "firefox-langpacks"

--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -5,7 +5,6 @@ modules:
   - type: "rpm-ostree"
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
-      - "https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-%OS_VERSION%/lilay-topgrade-fedora-%OS_VERSION%.repo"
     install:
       - "gnome-shell-extension-blur-my-shell"
       - "gnome-shell-extension-dash-to-dock"
@@ -18,7 +17,6 @@ modules:
       - "kvantum"
       - "nautilus-python"
       - "sushi"
-      - "topgrade"
     remove:
       - "distrobox"
       - "fuse-overlayfs"
@@ -52,6 +50,10 @@ modules:
     dest: "/"
   - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/qwhitesurgtkdecorations:latest"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/topgrade:latest"
     src: "/"
     dest: "/"
   - type: "copy"


### PR DESCRIPTION
Replace package `topgrade` provider from Fedora Copr to internal container.