### PR TITLE
fix: issues for `grand-os/main-testing:41.20250429.0`

### DIFF
--- a/containers/qwhitesurgtkdecorations/Containerfile
+++ b/containers/qwhitesurgtkdecorations/Containerfile
@@ -2,7 +2,7 @@ ARG BUILDER_VERSION=latest
 ARG REPOSITORY_VERSION
 
 # stage 1: build resources for system package.
-FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS system-builder
+FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder
 ARG REPOSITORY_VERSION
 
 # hadolint ignore=DL3041
@@ -40,60 +40,9 @@ RUN cmake \
     && cmake --build ./build-qt6 -j \
     && DESTDIR="./dist" cmake --install ./build-qt6
 
-# stage 2: build resources for flatpak package.
-FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS flatpak-builder
-ARG REPOSITORY_VERSION
-
-# hadolint ignore=DL3041
-RUN dnf --setopt="install_weak_deps=False" install --assumeyes \
-      cmake \
-      gcc-c++ \
-      git \
-      libstdc++ \
-      qt5-qtbase-private-devel \
-      qt5-qtbase-static \
-      qt5-qtsvg-devel \
-      qt5-qtwayland-devel \
-      qt6-qtbase-private-devel \
-      qt6-qtbase-static \
-      qt6-qtsvg-devel \
-      qt6-qtwayland-devel \
-      wayland-devel \
-    && dnf clean all
-
-RUN git clone https://github.com/FengZhongShaoNian/QWhiteSurGtkDecorations \
-      --branch="${REPOSITORY_VERSION}" \
-      --depth=1
-
-WORKDIR /QWhiteSurGtkDecorations
-RUN mkdir --parents /run/host \
-    && ln --symbolic /usr /run/host/usr \
-    && cmake \
-      -B build-qt5 \
-      -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_PREFIX_PATH=/run/host/usr \
-      -DCMAKE_CXX_FLAGS="-Wl,-rpath,/run/host/usr/lib64" \
-      -DHAS_QT6_SUPPORT=true \
-      -DUSE_QT6=false \
-    && cmake --build ./build-qt5 -j \
-    && DESTDIR="./dist/build" cmake --install ./build-qt5 \
-    && cmake \
-      -B build-qt6 \
-      -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_PREFIX_PATH=/run/host/usr \
-      -DCMAKE_CXX_FLAGS="-Wl,-rpath,/run/host/usr/lib64" \
-      -DUSE_QT6=true \
-    && cmake --build ./build-qt6 -j \
-    && DESTDIR="./dist/build" cmake --install ./build-qt6 \
-    && mkdir --parents ./dist/output/usr/share/grand-os/flatpak/libraries \
-    && cp -r ./dist/build/usr/lib64/* ./dist/output/usr/share/grand-os/flatpak/libraries/
-
-# stage 3: copy resources to distribution container.
+# stage 2: copy resources to distribution container.
 FROM scratch AS dist
 
-COPY --from=system-builder \
+COPY --from=builder \
   /QWhiteSurGtkDecorations/dist \
-  /
-COPY --from=flatpak-builder \
-  /QWhiteSurGtkDecorations/dist/output \
   /

--- a/files/gschema-overrides/zzz-grand-os.gschema.override
+++ b/files/gschema-overrides/zzz-grand-os.gschema.override
@@ -61,7 +61,7 @@ use-system-font = false
 
 [org.gnome.shell]
 favorite-apps = ['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Ptyxis.desktop']
-enabled-extensions = ['blur-my-shell@aunetx','clipboard-indicator@tudmotu.com','dash-to-dock@micxgx.gmail.com','gsconnect@andyholmes.github.io','inputmethod-shortcuts@osamu.debian.org','just-perfection-desktop@just-perfection','logomenu@aryan_k','native-window-placement@gnome-shell-extensions.gcampax.github.com','rounded-window-corners@fxgn','search-light@icedman.github.com','status-icons@gnome-shell-extensions.gcampax.github.com','tilingshell@ferrarodomenico.com','user-theme@gnome-shell-extensions.gcampax.github.com']
+enabled-extensions = ['blur-my-shell@aunetx','clipboard-indicator@tudmotu.com','dash-to-dock@micxgx.gmail.com','gsconnect@andyholmes.github.io','inputmethod-shortcuts@osamu.debian.org','just-perfection-desktop@just-perfection','logomenu@aryan_k','native-window-placement@gnome-shell-extensions.gcampax.github.com','rounded-window-corners@fxgn','search-light@icedman.github.com','status-icons@gnome-shell-extensions.gcampax.github.com','tilingshell@ferrarodomenico.com']
 
 [org.gnome.shell.extensions.blur-my-shell.dash-to-dock]
 blur = true
@@ -120,9 +120,6 @@ inner-gaps = 0
 layouts-json = '[{"id":"Default","tiles":[{"x":0,"y":0,"width":0.1,"height":1,"groups":[]},{"x":0,"y":0,"width":0.25,"height":1,"groups":[]},{"x":0,"y":0,"width":0.5,"height":1,"groups":[]},{"x":0.1,"y":0,"width":0.15,"height":1,"groups":[]},{"x":0.25,"y":0,"width":0.25,"height":1,"groups":[]},{"x":0.25,"y":0,"width":0.5,"height":1,"groups":[]},{"x":0.5,"y":0,"width":0.25,"height":1,"groups":[]},{"x":0.5,"y":0,"width":0.5,"height":1,"groups":[]},{"x":0.75,"y":0,"width":0.25,"height":1,"groups":[]}]}]'
 outer-gaps = 0
 show-indicator = false
-
-[org.gnome.shell.extensions.user-theme]
-name = "WhiteSur-Dark"
 
 [org.gnome.software]
 allow-updates = false

--- a/files/system/common/usr/share/grand-os/flatpak/overrides/global
+++ b/files/system/common/usr/share/grand-os/flatpak/overrides/global
@@ -6,7 +6,6 @@ sockets=!x11;wayland;!fallback-x11
 [Environment]
 ELECTRON_OZONE_PLATFORM_HINT=wayland
 GTK_THEME=WhiteSur-Dark
-QT_PLUGIN_PATH=/app/lib64/plugins:/app/lib/plugins:/usr/share/runtime/lib/plugins:/run/host/usr/share/grand-os/flatpak/libraries/qt6/plugins:/run/host/usr/share/grand-os/flatpak/libraries/qt5/plugins
 QT_WAYLAND_DECORATION=whitesur-gtk
 XDG_CONFIG_DIRS=/app/etc/xdg:/etc/xdg:/run/host/etc/xdg
 XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/run/host/usr/share

--- a/files/system/common/usr/share/grand-os/flatpak/overrides/global
+++ b/files/system/common/usr/share/grand-os/flatpak/overrides/global
@@ -9,4 +9,4 @@ GTK_THEME=WhiteSur-Dark
 QT_PLUGIN_PATH=/app/lib64/plugins:/app/lib/plugins:/usr/share/runtime/lib/plugins:/run/host/usr/share/grand-os/flatpak/libraries/qt6/plugins:/run/host/usr/share/grand-os/flatpak/libraries/qt5/plugins
 QT_WAYLAND_DECORATION=whitesur-gtk
 XDG_CONFIG_DIRS=/app/etc/xdg:/etc/xdg:/run/host/etc/xdg
-XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share/run/host/usr/share
+XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/run/host/usr/share

--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -12,7 +12,6 @@ modules:
       - "gnome-shell-extension-just-perfection"
       - "gnome-shell-extension-native-window-placement"
       - "gnome-shell-extension-status-icons"
-      - "gnome-shell-extension-user-theme"
       - "ibus-mozc"
       - "keyd"
       - "kvantum"


### PR DESCRIPTION
- Fix layout issues.
- Remove unused gnome extensions.
- Disable title-bar decorations for Qt app on flatpak.