### PR TITLE
feat: replace internal package to fedora copr

### DIFF
--- a/recipes/modules/old/copy-container-files.yaml
+++ b/recipes/modules/old/copy-container-files.yaml
@@ -10,11 +10,6 @@ modules:
       - "fc-cache --system-only --really-force /usr/share/fonts/hackgen"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/kde-rounded-corners:41"
-    src: "/"
-    dest: "/"
-
-  - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/kzones:41"
     src: "/"
     dest: "/"

--- a/recipes/modules/old/copy-container-files.yaml
+++ b/recipes/modules/old/copy-container-files.yaml
@@ -15,11 +15,6 @@ modules:
     dest: "/"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/topgrade:41"
-    src: "/"
-    dest: "/"
-
-  - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:41"
     src: "/"
     dest: "/"

--- a/recipes/modules/old/setup-packages.yaml
+++ b/recipes/modules/old/setup-packages.yaml
@@ -4,6 +4,7 @@ modules:
   - type: "rpm-ostree"
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
+      - "https://copr.fedorainfracloud.org/coprs/matinlotfali/KDE-Rounded-Corners/repo/fedora-%OS_VERSION%/matinlotfali-KDE-Rounded-Corners-fedora-%OS_VERSION%.repo"
       - "https://packagecloud.io/install/repositories/filips/FirefoxPWA/config_file.repo?os=rpm_any&dist=rpm_any&source=script"
     keys:
       - "https://packagecloud.io/filips/FirefoxPWA/gpgkey"
@@ -18,6 +19,7 @@ modules:
       - "kcm-fcitx5"
       - "keyd"
       - "kvantum"
+      - "kwin-effect-roundcorners"
       - "libappindicator"
       - "libdbusmenu"
     remove:

--- a/recipes/modules/old/setup-packages.yaml
+++ b/recipes/modules/old/setup-packages.yaml
@@ -4,6 +4,7 @@ modules:
   - type: "rpm-ostree"
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
+      - "https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-%OS_VERSION%/lilay-topgrade-fedora-%OS_VERSION%.repo"
       - "https://copr.fedorainfracloud.org/coprs/matinlotfali/KDE-Rounded-Corners/repo/fedora-%OS_VERSION%/matinlotfali-KDE-Rounded-Corners-fedora-%OS_VERSION%.repo"
       - "https://packagecloud.io/install/repositories/filips/FirefoxPWA/config_file.repo?os=rpm_any&dist=rpm_any&source=script"
     keys:
@@ -22,6 +23,7 @@ modules:
       - "kwin-effect-roundcorners"
       - "libappindicator"
       - "libdbusmenu"
+      - "topgrade"
     remove:
       - "distrobox"
       - "firefox-langpacks"

--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -5,6 +5,7 @@ modules:
   - type: "rpm-ostree"
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
+      - "https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-%OS_VERSION%/lilay-topgrade-fedora-%OS_VERSION%.repo"
     install:
       - "gnome-shell-extension-blur-my-shell"
       - "gnome-shell-extension-dash-to-dock"
@@ -17,6 +18,7 @@ modules:
       - "kvantum"
       - "nautilus-python"
       - "sushi"
+      - "topgrade"
     remove:
       - "distrobox"
       - "fuse-overlayfs"
@@ -50,10 +52,6 @@ modules:
     dest: "/"
   - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/qwhitesurgtkdecorations:41"
-    src: "/"
-    dest: "/"
-  - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/topgrade:41"
     src: "/"
     dest: "/"
   - type: "copy"


### PR DESCRIPTION
Replace the following packages managed by internal container with rpm packages managed in Fedora Copr repository.

- `kde-rounded-corners` -> [`matinlotfali/KDE-Rounded-Corners`](https://copr.fedorainfracloud.org/coprs/matinlotfali/KDE-Rounded-Corners)
- `topgrade` -> [`lilay/topgrade`](https://copr.fedorainfracloud.org/coprs/lilay/topgrade)