### PR TITLE
fix: issues for `grand-os/main-testing:41.20250502.0`

### DIFF
--- a/files/gschema-overrides/zzz-grand-os.gschema.override
+++ b/files/gschema-overrides/zzz-grand-os.gschema.override
@@ -86,12 +86,12 @@ imkey-1 = ['Hangul']
 
 [org.gnome.shell.extensions.just-perfection]
 activities-button = false
-clock-menu-position = 1
-clock-menu-position-offset = 20
-notification-banner-position = 2
 overlay-key = false
 panel-button-padding-size = 6
+quick-settings-dark-mode = false
+quick-settings-night-light = false
 startup-status = 0
+support-notifier-type = 0
 
 [org.gnome.shell.extensions.logo-menu]
 symbolic-icon = true

--- a/files/system/common/usr/lib/systemd/system-preset/91-grand-os-keyboard-remapping.preset
+++ b/files/system/common/usr/lib/systemd/system-preset/91-grand-os-keyboard-remapping.preset
@@ -1,1 +1,0 @@
-enable keyd.service

--- a/files/system/common/usr/lib/systemd/user-preset/91-grand-os-user-configs-override.preset
+++ b/files/system/common/usr/lib/systemd/user-preset/91-grand-os-user-configs-override.preset
@@ -1,2 +1,0 @@
-enable flatpak-override-update.timer
-enable gnupg-unit-update.timer

--- a/recipes/modules/customization/common.grand-os.yaml
+++ b/recipes/modules/customization/common.grand-os.yaml
@@ -25,7 +25,7 @@ modules:
     snippets:
       # Apply GTK4 theme.
       - "echo 'GTK_THEME=WhiteSur-Dark' >> /etc/environment"
-      # Apply GDM theme
+      # Apply GDM theme.
       - "
         cp
           /usr/share/themes/WhiteSur-Extension/gdm/gnome-shell-theme.gresource

--- a/recipes/modules/customization/common.grand-os.yaml
+++ b/recipes/modules/customization/common.grand-os.yaml
@@ -7,6 +7,16 @@ modules:
       - source: "./system/common"
         destination: "/"
 
+  # Add grand-os image info.
+  - type: "script"
+    scripts:
+      - "./add-image-info.sh"
+
+  # Add default kargs to bootc config.
+  - type: "script"
+    scripts:
+      - "./apply-default-kargs.sh"
+
   # Apply gnome/gtk customizations.
   - type: "gschema-overrides"
     include:
@@ -28,12 +38,12 @@ modules:
           /usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/
         "
 
-  # Add default kargs to bootc config.
-  - type: "script"
-    scripts:
-      - "./apply-default-kargs.sh"
-
-  # Add grand-os image info.
-  - type: "script"
-    scripts:
-      - "./add-image-info.sh"
+  # Enable systemd units.
+  - type: "systemd"
+    system:
+      enabled:
+        - "keyd.service"
+    user:
+      enabled:
+        - "flatpak-override-update.timer"
+        - "gnupg-unit-update.timer"


### PR DESCRIPTION
- Fix gnome shell layouts.
- Fix issues where systemd units can't enable on first startup.