### PR TITLE
ci: remove unnecessary container label

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -170,6 +170,14 @@ jobs:
             --verbose \
             "${RECIPE_PATH}"
 
+          sed \
+            --expression="/LABEL org.opencontainers.image.title/d" \
+            --expression="/LABEL org.opencontainers.image.description/d" \
+            --expression="/LABEL org.opencontainers.image.source/d" \
+            --expression="/LABEL org.opencontainers.image.created/d" \
+            --expression="/LABEL io.artifacthub/d" \
+            --in-place ./Containerfile
+
       - name: "Build image (and publish on release)"
         id: "build_image"
         uses: "docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1" # v6.16.0


### PR DESCRIPTION
Remove unnecessary and duplicated container label
(e.g.: `io.artifacthub.*`)
on main image.