### PR TITLE
feat: bump `grand-os/main` to Fedora 42

### DIFF
--- a/recipes/general/main.yaml
+++ b/recipes/general/main.yaml
@@ -4,7 +4,7 @@ name: "grand-os/main"
 description: "A desktop Linux image based for Fedora Kinoite and customized for personal use."
 
 base-image: "ghcr.io/ublue-os/kinoite-main"
-image-version: "41"
+image-version: "42"
 
 modules:
   - from-file: "./modules/old/setup-packages.yaml"

--- a/recipes/modules/old/copy-container-files.yaml
+++ b/recipes/modules/old/copy-container-files.yaml
@@ -2,7 +2,7 @@
 
 modules:
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/hackgen-fonts:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/hackgen-fonts:42"
     src: "/"
     dest: "/"
   - type: "script"
@@ -10,26 +10,26 @@ modules:
       - "fc-cache --system-only --really-force /usr/share/fonts/hackgen"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/kzones:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/kzones:42"
     src: "/"
     dest: "/"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:42"
     src: "/"
     dest: "/"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-gtk-theme:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-gtk-theme:42"
     src: "/"
     dest: "/"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-icon-theme:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-icon-theme:42"
     src: "/"
     dest: "/"
 
   - type: "copy"
-    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-kde:41"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-kde:42"
     src: "/"
     dest: "/"


### PR DESCRIPTION
Bump GrandOS Main OS Image Version to Fedora 42.