### PR TITLE
fix(deps): change gnome extension provider

### DIFF
--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -6,15 +6,12 @@ modules:
     repos:
       - "https://copr.fedorainfracloud.org/coprs/alternateved/keyd/repo/fedora-%OS_VERSION%/alternateved-keyd-fedora-%OS_VERSION%.repo"
       - "https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-%OS_VERSION%/lilay-topgrade-fedora-%OS_VERSION%.repo"
-      - "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-%OS_VERSION%/ublue-os-staging-fedora-%OS_VERSION%.repo"
     install:
       - "gnome-shell-extension-blur-my-shell"
       - "gnome-shell-extension-dash-to-dock"
       - "gnome-shell-extension-gsconnect"
       - "gnome-shell-extension-just-perfection"
-      - "gnome-shell-extension-logo-menu"
       - "gnome-shell-extension-native-window-placement"
-      - "gnome-shell-extension-search-light"
       - "gnome-shell-extension-status-icons"
       - "ibus-mozc"
       - "keyd"
@@ -31,9 +28,6 @@ modules:
       - "kasumi-common"
       - "kasumi-unicode"
       - "toolbox"
-  - type: "script"
-    snippets:
-      - "dnf config-manager setopt copr:copr.fedorainfracloud.org:ublue-os:staging.enabled=0"
 
   # Flatpak packages.
   - type: "default-flatpaks"
@@ -54,6 +48,10 @@ modules:
   # Internal container images.
   - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/gnome-shell-extension-inputmethod-shortcuts:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/gnome-shell-extension-search-light:42"
     src: "/"
     dest: "/"
   - type: "copy"
@@ -85,6 +83,7 @@ modules:
   - type: "gnome-extensions"
     install:
       - "779" # https://extensions.gnome.org/extension/779/clipboard-indicator
+      - "4451" # https://extensions.gnome.org/extension/4451/logo-menu
       - "7048" # https://extensions.gnome.org/extension/7048/rounded-window-corners-reborn
       - "7065" # https://extensions.gnome.org/extension/7065/tiling-shell
 


### PR DESCRIPTION
Change gnome extension provider.
Because of the need to manually patch to update to Fedora 42.