### PR TITLE
fix: issues where some GSchema setting values couldn't be retrieve

### DIFF
--- a/containers/gnome-shell-extension-inputmethod-shortcuts/Containerfile
+++ b/containers/gnome-shell-extension-inputmethod-shortcuts/Containerfile
@@ -28,3 +28,6 @@ FROM scratch
 COPY --from=builder \
     /inputmethod-shortcuts/dist \
     /usr/share/gnome-shell/extensions/inputmethod-shortcuts@osamu.debian.org
+COPY --from=builder \
+    /inputmethod-shortcuts/dist/schemas/org.gnome.shell.extensions.inputmethod-shortcuts.gschema.xml \
+    /usr/share/glib-2.0/schemas/

--- a/containers/gnome-shell-extension-search-light/Containerfile
+++ b/containers/gnome-shell-extension-search-light/Containerfile
@@ -21,7 +21,8 @@ RUN git init \
     && git checkout FETCH_HEAD \
     && git apply /tmp/patches/*.patch
 
-RUN make publish
+RUN make build \
+    && make publish
 
 # stage 2: copy extension to distribution container.
 FROM scratch
@@ -29,3 +30,6 @@ FROM scratch
 COPY --from=builder \
     /search-light/build \
     /usr/share/gnome-shell/extensions/search-light@icedman.github.com
+COPY --from=builder \
+    /search-light/build/schemas/org.gnome.shell.extensions.search-light.gschema.xml \
+    /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
The schema must be placed in `/usr/share/glib-2.0` to compile GSchema at OS build time,
but the Gnome Extension built with Internal Container did not place the schema in `/usr/lib/glib-2.0`.