### PR TITLE
feat(deps): add internal container `darwinmenu-plasma-applet`

### DIFF
--- a/containers/darwinmenu-plasma-applet/Containerfile
+++ b/containers/darwinmenu-plasma-applet/Containerfile
@@ -1,0 +1,27 @@
+ARG BUILDER_VERSION=42
+ARG REPOSITORY_VERSION=v0.9.1
+
+# stage 1: build script.
+FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder
+ARG BUILDER_VERSION
+ARG REPOSITORY_VERSION
+
+# hadolint ignore=DL3041
+RUN dnf --setopt="install_weak_deps=False" install --assumeyes \
+      git \
+      kf6-kpackage \
+    && dnf clean all
+
+RUN git clone https://github.com/Latgardi/darwinmenu \
+      --branch="${REPOSITORY_VERSION}" \
+      --depth=1
+
+WORKDIR /darwinmenu
+RUN kpackagetool6 --packageroot=/darwinmenu/dist --install=./package
+
+# stage 2: copy script to distribution container.
+FROM scratch AS dist
+
+COPY --from=builder \
+    /darwinmenu/dist \
+    /usr/share/plasma/plasmoids/

--- a/containers/darwinmenu-plasma-applet/README.md
+++ b/containers/darwinmenu-plasma-applet/README.md
@@ -1,0 +1,11 @@
+# `grand-os/internal/darwinmenu-plasma-applet`
+
+Internal container image to provide
+[github.com/Latgardi/darwinmenu](https://github.com/Latgardi/darwinmenu)
+into GrandOS.
+
+## Build
+
+```shell
+podman build --tag="ghcr.io/rshirohara/grand-os/internal/darwinmenu-plasma-applet:edge" .
+```

--- a/containers/darwinmenu-plasma-applet/meta.json
+++ b/containers/darwinmenu-plasma-applet/meta.json
@@ -1,0 +1,9 @@
+{
+  "org.opencontainers.image.authors": "Ray Shirohara <RShirohara@proton.me>",
+  "org.opencontainers.image.url": "https://github.com/RShirohara/grand-os/blob/main/containers/darwinmenu-plasma-applet",
+  "org.opencontainers.image.documentation": "https://github.com/RShirohara/grand-os/blob/main/containers/darwinmenu-plasma-applet/README.md",
+  "org.opencontainers.image.source": "https://github.com/RShirohara/grand-os/blob/main/containers/darwinmenu-plasma-applet/Containerfile",
+  "org.opencontainers.image.licenses": "BSD-2-Clause",
+  "org.opencontainers.image.title": "grand-os/internal/darwinmenu-plasma-applet",
+  "org.opencontainers.image.description": "Internal container image to provide github.com/Latgardi/darwinmenu into GrandOS."
+}


### PR DESCRIPTION
Add internasl container `darwinmenu-plasma-applet`.
Because dependency cannot resolve from KDE Store.