### PR TITLE
fix: issues for `grand-os/main-testing:42.20250518.1`

### DIFF
--- a/files/system/common/etc/xdg/dolphinrc
+++ b/files/system/common/etc/xdg/dolphinrc
@@ -1,0 +1,8 @@
+[DetailsMode]
+PreviewSize=16
+
+[General]
+RememberOpenedTabs=false
+
+[IconsMode]
+PreviewSize=16

--- a/files/system/common/usr/share/plasma/look-and-feel/com.github.rshirohara.grand-os/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/files/system/common/usr/share/plasma/look-and-feel/com.github.rshirohara.grand-os/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -1,16 +1,17 @@
 var plasma = getApiVersion(1);
 
 var layout = {
+  "serializationFormatVersion": "1",
   "desktops": [
     {
-      "applets": [],
+      "wallpaperPlugin": "org.kde.image",
       "config": {
         "/Wallpaper/org.kde.image/General": {
           "Image": "/usr/share/wallpapers/Mountain",
           "SlidePaths": "/usr/share/wallpapers/"
-        }
+        },
       },
-      "wallpaperPlugin": "org.kde.image"
+      "applets": [],
     }
   ],
   "panels": [
@@ -18,58 +19,68 @@ var layout = {
       "location": "top",
       "alignment": "left",
       "offset": 0,
+      "lengthMode": "fill",
       "height": 1.5,
-      "hiding": "normal",
+      "hiding": "none",
+      "floating": false,
+      "opacity": "adaptive",
       "config": {},
       "applets": [
         // TODO: add Darwin menu.
         // Ref: https://store.kde.org/p/2157390
         {
           "plugin": "org.kde.plasma.windowlist",
-          "config": {}
+          "config": {},
         },
         {
           "plugin": "org.kde.plasma.appmenu",
-          "config": {}
+          "config": {},
         },
         {
           "plugin": "org.kde.plasma.panelspacer",
-          "config": {}
+          "config": {},
         },
         {
           "plugin": "org.kde.plasma.systemtray",
-          "config": {}
+          "config": {
+            "extraItems": "org.kde.kdeconnect,org.kde.plasma.battery,org.kde.plasma.bluetooth,org.kde.plasma.clipboard,org.kde.plasma.devicenotifier,org.kde.plasma.mediacontroller,org.kde.plasma.networkmanagement,org.kde.plasma.volume",
+            "knownItems": "org.kde.kdeconnect,org.kde.kscreen,org.kde.plasma.battery,org.kde.plasma.bluetooth,org.kde.plasma.brightness,org.kde.plasma.cameraindicator,org.kde.plasma.clipboard,org.kde.plasma.devicenotifier,org.kde.plasma.keyboardindicator,org.kde.plasma.keyboardlayout,org.kde.plasma.manage-inputmethod,org.kde.plasma.mediacontroller,org.kde.plasma.networkmanagement,org.kde.plasma.notifications,org.kde.plasma.printmanager,org.kde.plasma.vault,org.kde.plasma.volume",
+            "showAllItems": true,
+          },
         },
         {
           "plugin": "org.kde.plasma.digitalclock",
           "config": {
             "/Appearance": {
               "displayTimezoneFormat": "FullText",
-              "use24hFormat": "2"
-            }
-          }
+              "use24hFormat": "2",
+            },
+          },
         },
         {
           "plugin": "org.kde.plasma.notifications",
-          "config": {}
-        }
+          "config": {},
+        },
       ],
     },
     {
       "location": "bottom",
       "alignment": "center",
       "offset": 0,
-      "height": 3.25,
+      "lengthMode": "fit",
+      "height": 2.75,
       "hiding": "dodgewindows",
+      "floating": true,
+      "opacity": "adaptive",
       "config": {},
       "applets": [
         {
           "plugin": "org.kde.plasma.icontasks",
           "config": {
             "/General": {
-              "launchers": "applications:trivalent.desktop,preferred://filemanager,preferred://terminal"
-            }
-          }
+              "launchers": "applications:trivalent.desktop,applications:org.kde.dolphin.desktop,applications:org.kde.konsole.desktop"
+            },
+          },
         },
         {
           "plugin": "org.kde.plasma.folder",
@@ -77,14 +88,13 @@ var layout = {
             "/General": {
               "icon": "trash-empty",
               "useCustomIcon": "true",
-              "url": "trash:/"
-            }
-          }
+              "url": "trash:/",
+            },
+          },
         },
       ],
-    }
+    },
   ],
-  "serializationFormatVersion": "1"
-};
+}
 
 plasma.loadSerializedLayout(layout);

--- a/files/system/common/usr/share/plasma/look-and-feel/com.github.rshirohara.grand-os/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/files/system/common/usr/share/plasma/look-and-feel/com.github.rshirohara.grand-os/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -26,8 +26,17 @@ var layout = {
       "opacity": "adaptive",
       "config": {},
       "applets": [
-        // TODO: add Darwin menu.
-        // Ref: https://store.kde.org/p/2157390
+        {
+          "plugin": "org.latgardi.darwinmenu",
+          "config": {
+            "/Configuration/General": {
+              "customButtonImage": "hamburger-menu-symbolic",
+              "iconSizePercent": 50,
+              "useCustomButtonImage": true,
+              "useRectangleButtonShape": false,
+            },
+          },
+        },
         {
           "plugin": "org.kde.plasma.windowlist",
           "config": {},

--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -61,6 +61,10 @@ modules:
 
   # Internal container images.
   - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/darwinmenu-plasma-applet:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
     from: "ghcr.io/rshirohara/grand-os/internal/hackgen-fonts:42"
     src: "/"
     dest: "/"


### PR DESCRIPTION
Fix issues for `grand-os/main-testing:42.20250518.1`.

- Fix default desktop layout.
  - Add applet `org.latgardi.darwinmenu`.
- Add dolphin default config.