### PR TITLE
feat: add internal container `trivalent-widevine`

### DIFF
--- a/containers/trivalent-widevine/Containerfile
+++ b/containers/trivalent-widevine/Containerfile
@@ -9,11 +9,12 @@ RUN dnf --setopt="install_weak_deps=False" install --assumeyes \
     && dnf clean all
 
 WORKDIR /widevine-cdm
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN VERSION=$(curl --location https://dl.google.com/widevine-cdm/versions.txt | tail --lines=1) \
     && curl \
       --location \
       --output ./widevine.zip \
-      https://dl.google.com/widevine-cdm/${VERSION}-linux-x64.zip \
+      "https://dl.google.com/widevine-cdm/${VERSION}-linux-x64.zip" \
     && unzip widevine.zip \
     && install --directory --mode=755 ./dist/WidevineCdm/_platform_specific/linux_x64 \
     && install --mode=644 ./LICENSE.txt ./dist/WidevineCdm/ \

--- a/containers/trivalent-widevine/Containerfile
+++ b/containers/trivalent-widevine/Containerfile
@@ -1,0 +1,28 @@
+ARG BUILDER_VERSION=42
+
+# stage 1: download resource.
+FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder
+
+# hadolint ignore=DL3041
+RUN dnf --setopt="install_weak_deps=False" install --assumeyes \
+      unzip \
+    && dnf clean all
+
+WORKDIR /widevine-cdm
+RUN VERSION=$(curl --location https://dl.google.com/widevine-cdm/versions.txt | tail --lines=1) \
+    && curl \
+      --location \
+      --output ./widevine.zip \
+      https://dl.google.com/widevine-cdm/${VERSION}-linux-x64.zip \
+    && unzip widevine.zip \
+    && install --directory --mode=755 ./dist/WidevineCdm/_platform_specific/linux_x64 \
+    && install --mode=644 ./LICENSE.txt ./dist/WidevineCdm/ \
+    && install --mode=644 ./manifest.json ./dist/WidevineCdm/ \
+    && install --mode=644 ./libwidevinecdm.so ./dist/WidevineCdm/_platform_specific/linux_x64/
+
+# stage 2: copy resource to distribution container.
+FROM scratch AS dist
+
+COPY --from=builder \
+    /widevine-cdm/dist \
+    /usr/lib64/trivalent

--- a/containers/trivalent-widevine/README.md
+++ b/containers/trivalent-widevine/README.md
@@ -1,0 +1,10 @@
+# `grand-os/internal/trivalent-widevine`
+
+Internal container image to provide [widevine](https://www.widevine.com/) DRM support
+to Trivalent.
+
+## Build
+
+```shell
+podman build --tag="ghcr.io/rshirohara/grand-os/internal/trivalent-widevine:edge" .
+```

--- a/containers/trivalent-widevine/meta.json
+++ b/containers/trivalent-widevine/meta.json
@@ -1,0 +1,9 @@
+{
+  "org.opencontainers.image.authors": "Ray Shirohara <RShirohara@proton.me>",
+  "org.opencontainers.image.url": "https://github.com/RShirohara/grand-os/blob/main/containers/trivalent-widevine",
+  "org.opencontainers.image.documentation": "https://github.com/RShirohara/grand-os/blob/main/containers/trivalent-widevine/README.md",
+  "org.opencontainers.image.source": "https://github.com/RShirohara/grand-os/blob/main/containers/trivalent-widevine/Containerfile",
+  "org.opencontainers.image.licenses": "",
+  "org.opencontainers.image.title": "grand-os/internal/trivalent-widevine",
+  "org.opencontainers.image.description": "Internal container image to provide widevine DRM support to Trivalent."
+}


### PR DESCRIPTION
Add internal container image to provide [widevine](https://www.widevine.com/) DRM support to Trivalent.