### PR TITLE
fix: issues for `grand-os/main:42.20250607.0`

### DIFF
--- a/containers/trivalent-widevine/Containerfile
+++ b/containers/trivalent-widevine/Containerfile
@@ -5,6 +5,7 @@ FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder
 
 # hadolint ignore=DL3041
 RUN dnf --setopt="install_weak_deps=False" install --assumeyes \
+      jq \
       unzip \
     && dnf clean all
 
@@ -15,7 +16,11 @@ RUN VERSION=$(curl --location https://dl.google.com/widevine-cdm/versions.txt | 
       --location \
       --output ./widevine.zip \
       "https://dl.google.com/widevine-cdm/${VERSION}-linux-x64.zip" \
-    && unzip widevine.zip \
+    && unzip ./widevine.zip \
+    && jq 'del(.arch, .os) | ."x-cdm-supported-encryption-schemes" = ["cenc", "cbcs"] | .platforms.[0] = {"os": "linux", "arch": "x64", "sub_package_path": "_platform_specific/linux_x64/"} ' \
+      ./manifest.json \
+      > ./manifest.updated.json \
+    && mv manifest.updated.json manifest.json \
     && install --directory --mode=755 ./dist/WidevineCdm/_platform_specific/linux_x64 \
     && install --mode=644 ./LICENSE.txt ./dist/WidevineCdm/ \
     && install --mode=644 ./manifest.json ./dist/WidevineCdm/ \

--- a/containers/trivalent-widevine/Containerfile
+++ b/containers/trivalent-widevine/Containerfile
@@ -19,7 +19,7 @@ RUN VERSION=$(curl --location https://dl.google.com/widevine-cdm/versions.txt | 
     && install --directory --mode=755 ./dist/WidevineCdm/_platform_specific/linux_x64 \
     && install --mode=644 ./LICENSE.txt ./dist/WidevineCdm/ \
     && install --mode=644 ./manifest.json ./dist/WidevineCdm/ \
-    && install --mode=644 ./libwidevinecdm.so ./dist/WidevineCdm/_platform_specific/linux_x64/
+    && install --mode=755 ./libwidevinecdm.so ./dist/WidevineCdm/_platform_specific/linux_x64/
 
 # stage 2: copy resource to distribution container.
 FROM scratch AS dist

--- a/files/system/common/etc/profile.d/grand-os.sh
+++ b/files/system/common/etc/profile.d/grand-os.sh
@@ -12,7 +12,7 @@ export XCURSOR_PATH="${XDG_DATA_HOME:-${HOME}/.local/share}/icons:/usr/share/ico
 # Override GnuPG default config directory.
 export GNUPGHOME="${XDG_DATA_HOME:-${HOME}/.local/share}/gnupg"
 if [[ ! -d "${GNUPGHOME}" ]]; then
-  mkdir --parents "${GNUPGHOME}"
+  mkdir --mode=700 --parents "${GNUPGHOME}"
 fi
 
 # Override GTK1 & 2 config directory location.


### PR DESCRIPTION
- Fix permission for widevine shared library.
- Add missing metadata to widevine.
- Fix permission for `${GNUPGHOME}` directory creation process.