### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* RShirohara@proton.me
+* @RShirohara


### PR DESCRIPTION
Update the CODEOWNERS notation to use GitHub account IDs.