### PR TITLE
feat: add silverblue based testing image

### DIFF
--- a/files/gschema-overrides/zz2-grand-os.gschema.override
+++ b/files/gschema-overrides/zz2-grand-os.gschema.override
@@ -1,0 +1,127 @@
+[org.gnome.desktop.background]
+picture-uri = 'file:///usr/share/backgrounds/fedora-workstation/glasscurtains_light.webp'
+picture-uri-dark = 'file:///usr/share/backgrounds/fedora-workstation/glasscurtains_dark.webp'
+
+[org.gnome.desktop.interface]
+clock-format = '24h'
+color-scheme = 'prefer-dark'
+cursor-theme = 'WhiteSur-cursors'
+document-font-name = 'Noto Sans CJK JP, Light 11'
+enable-animations = true
+enable-hot-corners = false
+font-name = 'Noto Sans CJK JP, Light 11'
+gtk-im-module = 'ibus'
+gtk-theme = 'WhiteSur-Dark'
+icon-theme = 'WhiteSur-dark'
+monospace-font-name = 'HackGen 11'
+toolbar-style = 'both'
+
+[org.gnome.desktop.media-handling]
+automount = false
+automount-open = false
+
+[org.gnome.desktop.sound]
+theme-name = 'ocean'
+
+[org.gnome.desktop.wm.keybindings]
+show-desktop = ['<Super>d']
+switch-applications = ['<Super>Tab']
+switch-applications-backward = ['<Shift><Super>Tab']
+switch-windows = ['<Alt>Tab']
+switch-windows-backward = ['<Shift><Alt>Tab']
+switch-input-source = ['<Shift><Super>space']
+switch-input-source-backward = ['']
+unmaximize = ['<Super>Down']
+activate-window-menu = []
+
+[org.gnome.desktop.wm.preferences]
+button-layout = 'close,minimize,maximize:'
+theme = 'WhiteSur-Dark'
+titlebar-font = 'Noto Sans CJK JP, Light 11'
+
+[org.gnome.nautilus.compression]
+default-compression-format = 'tar.xz'
+
+[org.gnome.nautilus.icon-view]
+default-zoom-level = 'small'
+
+[org.gnome.nautilus.list-view]
+default-visible-columns = ['name', 'type', 'size', 'date_modified']
+default-zoom-level = 'small'
+use-tree-view = true
+
+[org.gnome.nautilus.preferences]
+default-folder-viewer = 'list-view'
+migrated-gtk-settings = true
+
+[org.gnome.Ptyxis]
+cursor-shape = 'ibeam'
+font-name = 'HackGen Console NF 11'
+use-system-font = false
+
+[org.gnome.shell]
+favorite-apps = ['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Ptyxis.desktop']
+enabled-extensions = ['blur-my-shell@aunetx','clipboard-indicator@tudmotu.com','dash-to-dock@micxgx.gmail.com','gsconnect@andyholmes.github.io','just-perfection-desktop@just-perfection','logomenu@aryan_k','native-window-placement@gnome-shell-extensions.gcampax.github.com','rounded-window-corners@fxgn','search-light@icedman.github.com','status-icons@gnome-shell-extensions.gcampax.github.com']
+
+[org.gnome.shell.extensions.blur-my-shell.dash-to-dock]
+blur = true
+
+[org.gnome.shell.extensions.clipboard-indicator]
+clear-history = []
+clear-on-boot = true
+confirm-clear = false
+history-size = 20
+next-entry = []
+prev-entry = []
+private-mode-binding = []
+toggle-menu = ['<Super>v']
+
+[org.gnome.shell.extensions.dash-to-dock]
+apply-custom-theme = true
+show-show-apps-button = false
+
+[org.gnome.shell.extensions.just-perfection]
+activities-button = false
+overlay-key = false
+panel-button-padding-size = 6
+quick-settings-dark-mode = false
+quick-settings-night-light = false
+startup-status = 0
+support-notifier-type = 0
+
+[org.gnome.shell.extensions.logo-menu]
+hide-forcequit = true
+menu-button-icon-image = 1
+menu-button-icon-size = 18
+menu-button-software-center = 'gnome-software'
+menu-button-system-monitor = 'flatpak run --user io.missioncenter.MissionCenter'
+menu-button-terminal = 'ptyxis'
+show-activities-button = false
+show-lockscreen = false
+show-power-options = false
+symbolic-icon = true
+
+[org.gnome.shell.extensions.search-light]
+background-color = (0.0, 0.0, 0.0, 0.3)
+border-color = (0.23, 0.23, 0.23, 1.0)
+border-radius = 1.65
+border-thickness = 1
+scale-height = 0.15
+scale-width = 0.10
+shortcut-search = ['<Super>Space']
+
+[org.gnome.software]
+allow-updates = false
+download-updates = false
+download-updates-notify = false
+
+[org.gnome.tweaks]
+show-extensions-notice = false
+
+[org.gtk.gtk4.Settings.FileChooser]
+show-hidden = true
+sort-directories-first = true
+
+[org.gtk.Settings.FileChooser]
+show-hidden = true
+sort-directories-first = true

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
+
+name: "grand-os/main"
+description: "A desktop Linux image based for Fedora Silverblue and customized for personal use."
+
+base-image: "ghcr.io/secureblue/silverblue-main-hardened"
+image-version: "42"
+
+modules:
+  - from-file: "./modules/packages/testing.yaml"
+  - from-file: "./modules/customization/testing.yaml"
+  - from-file: "./modules/postprocess/common.yaml"

--- a/recipes/modules/customization/testing.grand-os.yaml
+++ b/recipes/modules/customization/testing.grand-os.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-list-v1.json
+
+modules:
+  # Apply file-based customizations.
+  - type: "files"
+    files:
+      - source: "./system/common"
+        destination: "/"
+
+  # Add grand-os image info.
+  - type: "script"
+    scripts:
+      - "./add-image-info.sh"
+
+  # Add default kargs to bootc config.
+  - type: "script"
+    scripts:
+      - "./apply-default-kargs.sh"
+
+  # Change rebase-image refs on securebluecleanup script.
+  - type: "script"
+    scripts:
+      - "./update-cleanup-refs.sh"
+
+  # Apply GTK theme customization.
+  - type: "gschema-overrides"
+    include:
+      - "zz2-grand-os.gschema.override"
+  - type: "script"
+    snippets:
+      # Apply GTK Theme.
+      - "echo 'GTK_THEME=WhiteSur-Dark' >> /etc/environment"
+      # Apply GDM theme.
+      - "
+        cp
+        /usr/share/themes/WhiteSur-Extension/gdm/gnome-shell-theme.gresource
+        /usr/share/gnome-shell/
+        "
+      # Apply gnome extension `dash-to-dock` theme.
+      - "
+        cp
+        /usr/share/themes/WhiteSur-Extension/dash-to-dock/stylesheet.css
+        /usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/
+        "
+
+  # Apply KDE theme customization.
+  - type: "script"
+    snippets:
+      # Apply customization to WhiteSur Kvantum theme.
+      - "
+        sed
+        --expression='s|^transparent_dolphin_view=.*|transparent_dolphin_view=false|'
+        --expression='s|^scrollbar_in_view=.*|scrollbar_in_view=true|'
+        --in-place /usr/share/Kvantum/WhiteSur/WhiteSur*.kvconfig
+        "
+
+  # Enable systemd units.
+  - type: "systemd"
+    system:
+      enabled:
+        - "keyd.service"
+    user:
+      enabled:
+        - "flatpak-override-update.timer"
+        - "gnupg-unit-update.timer"

--- a/recipes/modules/customization/testing.yaml
+++ b/recipes/modules/customization/testing.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-list-v1.json
+
+modules:
+  - from-file: "./modules/customization/common.secureblue.yaml"
+  - from-file: "./modules/customization/testing.grand-os.yaml"

--- a/recipes/modules/packages/testing.yaml
+++ b/recipes/modules/packages/testing.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-list-v1.json
+
+modules:
+  # dnf packages.
+  - type: "dnf"
+    repos:
+      copr:
+        - "alternateved/keyd"
+        - "lilay/topgrade"
+      cleanup: false
+    install:
+      packages:
+        - "gnome-shell-extension-appindicator"
+        - "gnome-shell-extension-blur-my-shell"
+        - "gnome-shell-extension-dash-to-dock"
+        - "gnome-shell-extension-gsconnect"
+        - "gnome-shell-extension-just-perfection"
+        - "gnome-shell-extension-native-window-placement"
+        - "ibus-mozc"
+        - "keyd"
+        - "kvantum"
+        - "nautilus-python"
+        - "sushi"
+        - "topgrade"
+      install-weak-deps: false
+      skip-unavailable: false
+      skip-broken: false
+      allow-erasing: false
+    remove:
+      packages:
+        - "distrobox"
+        - "fuse-overlayfs"
+        - "ibus-anthy-python"
+        - "ibus-anthy"
+        - "ibus-typing-booster"
+        - "kasumi-common"
+        - "kasumi-unicode"
+        - "toolbox"
+      auto-remove: true
+
+  # Flatpak packages.
+  - type: "default-flatpaks"
+    user:
+      repo-url: "https://dl.flathub.org/repo/flathub.flatpakrepo"
+      repo-name: "flathub"
+      repo-title: "Flathub"
+      install:
+        - "ca.desrt.dconf-editor"
+        - "com.github.tchx84.Flatseal"
+        - "io.missioncenter.MissionCenter"
+        - "org.gnome.TextEditor"
+
+  # Internal container images.
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/hackgen-fonts:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/trivalent-widevine:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-gtk-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-icon-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-kde:42"
+    src: "/"
+    dest: "/"
+
+  # GNOME Shell Extensions.
+  - type: "gnome-extensions"
+    install:
+      - "779" # https://extensions.gnome.org/extension/779/clipboard-indicator
+      - "4442" # https://extensions.gnome.org/extension/4442/gsnap
+      - "4451" # https://extensions.gnome.org/extension/4451/logo-menu
+      - "5489" # https://extensions.gnome.org/extension/5489/search-light
+      - "7048" # https://extensions.gnome.org/extension/7048/rounded-window-corners-reborn
+      # TODO: input method selector integration
+      # TODO: tiling extension
+
+  # Homebrew.
+  - type: "brew"
+    brew-analytics: false
+    auto-update: true
+    auto-upgrade: true


### PR DESCRIPTION
Add `fedora-silverblue` based GNOME testing image.