### PR TITLE
ci: add missing permission

### DIFF
--- a/.github/workflows/build-flatpak.yaml
+++ b/.github/workflows/build-flatpak.yaml
@@ -113,6 +113,11 @@ jobs:
       - "build"
     runs-on: "${{ matrix.runner }}"
 
+    permissions:
+      attestations: "write"
+      id-token: "write"
+      packages: "write"
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fix an issue where the required permissions
were insufficient to add an image to GitHub Container Registry.