### PR TITLE
chore(deps): bump internal container dependency `secureblue/secureblue` to v4.6

### DIFF
--- a/containers/bluebuild-secureblue-signing/Containerfile
+++ b/containers/bluebuild-secureblue-signing/Containerfile
@@ -1,5 +1,5 @@
 ARG BUILDER_VERSION=42
-ARG REPOSITORY_VERSION=v4.5.1
+ARG REPOSITORY_VERSION=v4.6
 
 # stage 1: fetch module.
 FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder


### PR DESCRIPTION
Bump internal container dependency `secureblue/secureblue` to `v4.6`.
Ref: <https://github.com/secureblue/secureblue/releases/tag/v4.6>