### PR TITLE
fix: issue where dnf copr plugin could not get exactly the distribution type

### DIFF
--- a/files/system/dnf/usr/share/dnf/plugins/copr.vendor.conf
+++ b/files/system/dnf/usr/share/dnf/plugins/copr.vendor.conf
@@ -1,0 +1,2 @@
+[main]
+distribution = fedora

--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -2,6 +2,10 @@
 
 modules:
   # dnf packages.
+  - type: "files"
+    files:
+      - source: "./system/dnf"
+        destination: "/"
   - type: "dnf"
     repos:
       copr:


### PR DESCRIPTION
Fix build fails for <https://github.com/RShirohara/grand-os/actions/runs/16367180984>.