### PR TITLE
chore(deps): bump internal container whitesur-gtk-theme

### DIFF
--- a/containers/whitesur-gtk-theme/Containerfile
+++ b/containers/whitesur-gtk-theme/Containerfile
@@ -1,5 +1,5 @@
 ARG BUILDER_VERSION=42
-ARG REPOSITORY_VERSION=2025-06-14
+ARG REPOSITORY_VERSION=2025-07-24
 
 # stage 1: build theme.
 FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder


### PR DESCRIPTION
Bump internal container dependency `vinceliuice/WhiteSur-gtk-theme` to `2025-07-24.
Release Note: <https://github.com/vinceliuice/WhiteSur-gtk-theme/releases/tag/2025-07-24>