### PR TITLE
chore(deps): bump internal container whitesur-icon-theme

### DIFF
--- a/containers/whitesur-icon-theme/Containerfile
+++ b/containers/whitesur-icon-theme/Containerfile
@@ -1,5 +1,5 @@
 ARG BUILDER_VERSION=42
-ARG REPOSITORY_VERSION=v2025-02-10
+ARG REPOSITORY_VERSION=2025-07-29
 
 # stage 1: build icons.
 FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder


### PR DESCRIPTION
Bump internal container dependency `vinceliuice/WhiteSur-icon-theme` to `2025-07-29`.
Release Note: <https://github.com/vinceliuice/WhiteSur-icon-theme/releases/tag/2025-07-29>