### PR TITLE
feat: bump `default-flatpak` recipe version to v2

### DIFF
--- a/recipes/modules/packages/common.yaml
+++ b/recipes/modules/packages/common.yaml
@@ -53,17 +53,19 @@ modules:
 
   # Flatpak packages.
   - type: "default-flatpaks"
-    user:
-      repo-url: "https://dl.flathub.org/repo/flathub.flatpakrepo"
-      repo-name: "flathub"
-      repo-title: "Flathub"
-      install:
-        - "com.github.tchx84.Flatseal"
-        - "io.missioncenter.MissionCenter"
-        - "org.kde.gwenview"
-        - "org.kde.kwrite"
-        - "org.kde.okular"
-        - "org.videolan.VLC"
+    configurations:
+      - scope: "user"
+        repo:
+          title: "Flathub"
+          name: "flathub"
+          url: "https://dl.flathub.org/repo/flathub.flatpakrepo"
+        install:
+          - "com.github.tchx84.Flatseal"
+          - "io.missioncenter.MissionCenter"
+          - "org.kde.gwenview"
+          - "org.kde.kwrite"
+          - "org.kde.okular"
+          - "org.videolan.VLC"
 
   # Internal container images.
   - type: "copy"


### PR DESCRIPTION
Fix build fails for <https://github.com/RShirohara/grand-os/actions/runs/16671585894>.