### PR TITLE
chore(deps): bump internal container dependency `secureblue/secureblue` to v4.6.1

### DIFF
--- a/containers/bluebuild-secureblue-signing/Containerfile
+++ b/containers/bluebuild-secureblue-signing/Containerfile
@@ -1,5 +1,5 @@
 ARG BUILDER_VERSION=42
-ARG REPOSITORY_VERSION=v4.6
+ARG REPOSITORY_VERSION=v4.6.1
 
 # stage 1: fetch module.
 FROM registry.fedoraproject.org/fedora-minimal:${BUILDER_VERSION} AS builder

--- a/containers/bluebuild-secureblue-signing/README.md
+++ b/containers/bluebuild-secureblue-signing/README.md
@@ -7,5 +7,5 @@ into GrandOS.
 ## Build
 
 ```shell
-podman build --tag="ghcr.io/rshirohara/grand-os/internal/bluebuild-secureblue-signing:edge ."
+podman build --tag="ghcr.io/rshirohara/grand-os/internal/bluebuild-secureblue-signing:edge" .
 ```


### PR DESCRIPTION
Bump internal container dependency `secureblue/secureblue` to `v4.6.1`.
Ref: <https://github.com/secureblue/secureblue/releases/tag/v4.6.1>