### PR TITLE
ci: change linter installation method to `jdx/mise`

### DIFF
--- a/.github/workflows/check-actions.yaml
+++ b/.github/workflows/check-actions.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -o "errexit" -o "nounset"
 
-          actionlint --oneline \
+          mise run lint:github-action --format="oneline" \
           | reviewdog \
             --efm="%f:%l:%c: %m" \
             --name="Lint result (actionlint)" \

--- a/.github/workflows/check-containerfile.yaml
+++ b/.github/workflows/check-containerfile.yaml
@@ -39,7 +39,7 @@ jobs:
           set -o "errexit" -o "nounset"
 
           find . -type "f" -name "Containerfile" \
-            -exec hadolint --format="sarif" {} + \
+            -exec mise run lint:container --format="sarif" {} + \
           | reviewdog \
             -f="sarif" \
             --name="Lint result (hadolint)" \

--- a/.mise/tasks/lint/container
+++ b/.mise/tasks/lint/container
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#MISE description="Lint containerfile."
+#USAGE arg "<file>" help="Target file(s)." var=#true
+#USAGE flag "-f --format <format>" help="Output format." default="tty"
+
+set -o "errexit" -o "nounset" -o "pipefail"
+
+# shellcheck disable=SC2086
+hadolint --format="${usage_format:-}" ${usage_file:-}
+

--- a/.mise/tasks/lint/github-action
+++ b/.mise/tasks/lint/github-action
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#MISE description="Lint github-action workflow."
+#USAGE arg "[file]" help="Target file(s)." var=#true
+#USAGE flag "-f --format <format>" help="Output format" default="full" choices "full" "oneline"
+
+set -o "errexit" -o "nounset" -o "pipefail"
+
+flags=()
+if [[ "${usage_format:-}" == "oneline" ]]; then
+  flags=("${flags[@]}" "--oneline")
+fi
+
+# shellcheck disable=SC2086
+actionlint "${flags[@]}" ${usage_file:-}

--- a/.mise/tasks/lint/shellscript
+++ b/.mise/tasks/lint/shellscript
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#MISE description="Lint shellscript file."
+#USAGE arg "<file>" help="Target file(s)." var=#true
+#USAGE flag "-f --format <format>" help="Output format." default="tty"
+
+set -o "errexit" -o "nounset" -o "pipefail"
+
+# shellcheck disable=SC2086
+shellcheck --format="${usage_format:-}" ${usage_file:-}


### PR DESCRIPTION
Change the Linter installation method to use jdx/mise on ci process.
And use `mise run` commands on ci process.