### PR TITLE
feat: add silverblue based testing image

### DIFF
--- a/files/gschema-overrides/zz1-appearance.gschema.override
+++ b/files/gschema-overrides/zz1-appearance.gschema.override
@@ -1,0 +1,48 @@
+[org.gnome.desktop.interface]
+color-scheme = 'prefer-dark'
+cursor-theme = 'WhiteSur-cursors'
+document-font-name = 'Noto Sans CJK JP, Light 12'
+enable-animations = true
+enable-hot-corners = false
+font-name = 'Noto Sans CJK JP, Light 12'
+gtk-theme = 'WhiteSur-Dark'
+icon-theme = 'WhiteSur-dark'
+monospace-font-name = 'HackGen 12'
+toolbar-style = 'both'
+
+[org.gnome.desktop.sound]
+theme-name = 'ocean'
+
+[org.gnome.desktop.wm.preferences]
+button-layout = 'close,minimize,maximize:'
+theme = 'WhiteSur-Dark'
+titlebar-font = 'Noto Sans CJK JP, Light 11'
+
+[org.gnome.shell]
+# TODO: Add favorite apps
+favorite-apps = ['org.gnome.Nautilus.desktop']
+
+[org.gnome.shell.extensions.blur-my-shell.dash-to-dock]
+blur = true
+
+[org.gnome.shell.extensions.just-perfection]
+activities-button = false
+clock-menu-position = 1
+clock-menu-position-offset = 20
+notification-banner-position = 2
+overlay-key = false
+panel-button-padding-size = 6
+quick-settings-dark-mode = false
+quick-settings-night-light = false
+startup-status = 0
+support-notifier-type = 0
+
+[org.gnome.shell.extensions.logo-menu]
+# TODO: Add default app
+hide-forcequit = true
+menu-button-icon-image = 1
+menu-button-icon-size = 18
+show-activities-button = false
+show-lockscreen = false
+show-power-options = false
+symbolic-icon = true

--- a/files/gschema-overrides/zz1-keyboard.gschema.override
+++ b/files/gschema-overrides/zz1-keyboard.gschema.override
@@ -1,0 +1,17 @@
+[org.gnome.desktop.wm.keybindings]
+activate-window-menu = []
+show-desktop = ['<Super>d']
+switch-applications = ['<Super>Tab']
+switch-applications-backward = ['<Shift><Super>Tab']
+switch-windows = ['<Alt>Tab']
+switch-windows-backward = ['<Shift><Alt>Tab']
+switch-input-source = ['Hangul']
+switch-input-source-backward = ['Hangul_Hanja']
+unmaximize = ['<Super>Down']
+
+[org.gnome.shell.extensions.customize-ibus]
+fix-ime-list = true
+
+[org.gnome.shell.keybindings]
+focus-active-notification = []
+toggle-message-tray = ['<Super>m']

--- a/files/gschema-overrides/zz9-enable-extension.gschema.override
+++ b/files/gschema-overrides/zz9-enable-extension.gschema.override
@@ -1,0 +1,2 @@
+[org.gmone.shell]
+enabled-extensions = ['customize-ibus@hollowman.ml', 'quick-lang-switch@ankostis.gmail.com']

--- a/files/gschema-overrides/zz9-enable-extension.gschema.override
+++ b/files/gschema-overrides/zz9-enable-extension.gschema.override
@@ -1,2 +1,2 @@
 [org.gmone.shell]
-enabled-extensions = ['customize-ibus@hollowman.ml', 'quick-lang-switch@ankostis.gmail.com']
+enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'blur-my-shell@aunetx', 'customize-ibus@hollowman.ml', 'dash-to-dock@micxgx.gmail.com', 'just-perfection-desktop@just-perfection', 'logomenu@aryan_k', 'native-window-placement@gnome-shell-extensions.gcampax.github.com', 'quick-lang-switch@ankostis.gmail.com', 'rounded-window-corners@fxgn', 'search-light@icedman.github.com']

--- a/files/testing/customization/appearance/usr/lib/environment.d/50-desktop-theme.conf
+++ b/files/testing/customization/appearance/usr/lib/environment.d/50-desktop-theme.conf
@@ -1,0 +1,1 @@
+GTK_THEME=WhiteSur-Dark

--- a/files/testing/customization/font/etc/fonts/59-hackgen.conf
+++ b/files/testing/customization/font/etc/fonts/59-hackgen.conf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+
+	<!-- HackGen -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+	<!-- HackGen Console -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen Console</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen Console</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+	<!-- HackGen Console NF -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen Console NF</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen Console NF</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+	<!-- HackGen35 -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen35</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen35</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+	<!-- HackGen35 Console -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen35 Console</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen35 Console</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+	<!-- HackGen35 Console NF -->
+	<match>
+		<test name="family">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="prepend">
+			<string>HackGen35 Console NF</string>
+		</edit>
+	</match>
+	<alias>
+		<family>HackGen35 Console NF</family>
+		<default>
+			<family>monospace</family>
+		</default>
+	</alias>
+
+</fontconfig>

--- a/files/testing/customization/font/etc/fonts/69-os-default.conf
+++ b/files/testing/customization/font/etc/fonts/69-os-default.conf
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+
+	<!-- serif -->
+	<alias>
+		<family>serif</family>
+		<prefer>
+			<family>Noto Serif CJK JP</family>
+		</prefer>
+	</alias>
+
+	<!-- sans-serif -->
+	<alias>
+		<family>sans-serif</family>
+		<prefer>
+			<family>Noto Sans CJK JP</family>
+		</prefer>
+	</alias>
+
+	<!-- monospace -->
+	<alias>
+		<family>monospace</family>
+		<prefer>
+			<family>HackGen</family>
+		</prefer>
+	</alias>
+
+	<!-- system-ui -->
+	<alias>
+		<family>system-ui</family>
+		<prefer>
+			<family>Noto Sans CJK JP</family>
+		</prefer>
+	</alias>
+
+</fontconfig>

--- a/files/testing/customization/keyboard/etc/keyd/default.conf
+++ b/files/testing/customization/keyboard/etc/keyd/default.conf
@@ -1,0 +1,5 @@
+[ids]
+*
+
+[main]
+capslock = layer(control)

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
+
+name: "grand-os/main-testing"
+description: "A desktop Linux image based for Fedora Silverblue and customized for personal use."
+
+base-image: "quay.io/fedora-ostree-desktops/silverblue"
+image-version: "42"
+
+modules: []

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -11,3 +11,10 @@ modules:
   - from-file: "./modules/testing/customization/appearance.yaml"
   - from-file: "./modules/testing/customization/keyboard.yaml"
   - from-file: "./modules/testing/postprocess.yaml"
+
+# TODO: Add default-application (flatpak, homebrew, etc) module.
+# TODO: Add desktop clipboard integrator module.
+# TODO: Add desktop-tiling module.
+# TODO: Add system updater module.
+# TODO: Add kernel security module.
+# TODO: Add additional security module.

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -8,5 +8,6 @@ image-version: "42"
 
 modules:
   - from-file: "./modules/testing/customization/font.yaml"
+  - from-file: "./modules/testing/customization/appearance.yaml"
   - from-file: "./modules/testing/customization/keyboard.yaml"
   - from-file: "./modules/testing/postprocess.yaml"

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -6,4 +6,6 @@ description: "A desktop Linux image based for Fedora Silverblue and customized f
 base-image: "quay.io/fedora-ostree-desktops/silverblue"
 image-version: "42"
 
-modules: []
+modules:
+  - from-file: "./modules/testing/customization/font.yaml"
+  - from-file: "./modules/testing/postprocess.yaml"

--- a/recipes/general/main-testing.yaml
+++ b/recipes/general/main-testing.yaml
@@ -8,4 +8,5 @@ image-version: "42"
 
 modules:
   - from-file: "./modules/testing/customization/font.yaml"
+  - from-file: "./modules/testing/customization/keyboard.yaml"
   - from-file: "./modules/testing/postprocess.yaml"

--- a/recipes/modules/testing/customization/appearance.yaml
+++ b/recipes/modules/testing/customization/appearance.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
+
+stages: []
+
+modules:
+  # Install package from dnf.
+  - type: "dnf"
+    install:
+      packages:
+        - "gnome-shell-extension-appindicator"
+        - "gnome-shell-extension-blur-my-shell"
+        - "gnome-shell-extension-dash-to-dock"
+        - "gnome-shell-extension-just-perfection"
+        - "gnome-shell-extension-native-window-placement"
+        - "kvantum"
+      install-weak-deps: false
+      skip-unavailable: false
+      skip-broken: false
+      allow-erasing: false
+
+  # Install package from internal container.
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/qwhitesurgtkdecorations:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-cursor-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-gtk-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-icon-theme:42"
+    src: "/"
+    dest: "/"
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/whitesur-kde-kvantum:42"
+    src: "/"
+    dest: "/"
+
+  # Install package from gnome extensions.
+  - type: "gnome-extensions"
+    install:
+      - "4451" # https://extensions.gnome.org/extension/4451/logo-menu
+      - "7048" # https://extensions.gnome.org/extension/7048/rounded-window-corners-reborn
+
+  # Apply file-based customization.
+  - type: "files"
+    files:
+      - source: "./testing/customization/appearance"
+        destination: "/"
+
+  # Apply script-based customization.
+  - type: "script"
+    snippets:
+      # Apply GDM Theme.
+      - "install -D --mode=644 /usr/share/themes/WhiteSur-Extension/gdm/gnome-shell-theme.gresource /usr/share/gnome-shell/gnome-shell-theme.gresource"
+      # Apply `dash-to-dock` extension theme.
+      - "install -D --mode=644 /usr/share/themes/WhiteSur-Extension/dash-to-dock/stylesheet.css /usr/share/gnome-shell/extensions/dash-to-dock@micxgx.gmail.com/stylesheet.css"

--- a/recipes/modules/testing/customization/font.yaml
+++ b/recipes/modules/testing/customization/font.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
+
+stages: []
+
+modules:
+  # Install package from dnf.
+  - type: "dnf"
+    install:
+      packages:
+        - "last-resort-fonts"
+      install-weak-deps: false
+      skip-unavailable: false
+      skip-broken: false
+      allow-erasing: false
+
+  # Install package from internal container.
+  - type: "copy"
+    from: "ghcr.io/rshirohara/grand-os/internal/hackgen-fonts:42"
+    src: "/"
+    dest: "/"
+
+  # Apply file-based customization.
+  - type: "files"
+    files:
+      - source: "./testing/customization/font"
+        destination: "/"

--- a/recipes/modules/testing/customization/keyboard.yaml
+++ b/recipes/modules/testing/customization/keyboard.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
+
+stages: []
+
+modules:
+  # Install package from dnf.
+  - type: "dnf"
+    repos:
+      cleanup: true
+      copr:
+        - "alternateved/keyd"
+    install:
+      packages:
+        - "ibus-mozc"
+        - "keyd"
+      install-weak-deps: false
+      skip-unavailable: false
+      skip-broken: false
+      allow-erasing: false
+    remove:
+      packages:
+        - "ibus-anthy"
+        - "ibus-anthy-python"
+        - "ibus-typing-booster"
+        - "kasumi-common"
+        - "kasumi-unicode"
+      auto-remove: true
+
+  # Install package from gnome extensions.
+  - type: "gnome-extensions"
+    install:
+      - "4112" # https://extensions.gnome.org/extension/4112/customize-ibus/
+      - "4559" # https://extensions.gnome.org/extension/4559/quick-lang-switch/
+
+  # Apply file-based customization.
+  - type: "files"
+    files:
+      - source: "./testing/customization/keyboard"
+        destination: "/"

--- a/recipes/modules/testing/postprocess.yaml
+++ b/recipes/modules/testing/postprocess.yaml
@@ -7,3 +7,6 @@ modules:
   - type: "script"
     snippets:
       - "fc-cache --system-only --really-force /usr/share/fonts"
+
+  # Compile glib schema overrides.
+  - type: "gschema-overrides"

--- a/recipes/modules/testing/postprocess.yaml
+++ b/recipes/modules/testing/postprocess.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
+
+stages: []
+
+modules:
+  # Update font cache.
+  - type: "script"
+    snippets:
+      - "fc-cache --system-only --really-force /usr/share/fonts"


### PR DESCRIPTION
Add fedora-silverblue based testing image.

- Add font customization.
- Add keyboard customization.
- Add appearance customization.