### PR TITLE
chore: bump GrandOS image version to `v20251212.0`

### DIFF
--- a/files/scripts/update-os-release.sh
+++ b/files/scripts/update-os-release.sh
@@ -7,7 +7,7 @@ source /usr/lib/os-release
 
 NAME="GrandOS"
 ID="grand-os"
-RELEASE_VERSION="20251205.0"
+RELEASE_VERSION="20251212.0"
 VERSION="${VERSION_ID}.${RELEASE_VERSION}"
 REPO_URL="https://github.com/RShirohara/grand-os"
 REPO_ISSUE_URL="https://github.com/RShirohara/grand-os/issues"


### PR DESCRIPTION
Bump GrandOS image version to `v20251212.0`.

## Changelog

None.

## Notes

This pull request was created by workflow triggered by `schedule`.
Additional info:
> None.